### PR TITLE
Add CI to build with Docker

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,61 @@
+name: CI of mc_naoqi_dcm with Docker
+
+# This workflow checks the build-and-install script on base docker images
+
+on:
+  push:
+    paths-ignore:
+      # Changes to those files don't mandate running CI
+      - ".gitlab-ci.yml"
+      - ".jrl-ci"
+      - ".github/workflows/package.yml"
+      - "debian/**"
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu_20.04"]
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Build within Docker
+      run: |
+        echo "::group::Setup Dockerfile"
+        mkdir -p /tmp/mc_naoqi_dcm-docker
+        cp -r `pwd` /tmp/mc_naoqi_dcm-docker/mc_naoqi_dcm
+        cp .github/workflows/docker/Dockerfile.${{ matrix.os }} /tmp/mc_naoqi_dcm-docker/Dockerfile
+        cd /tmp/mc_naoqi_dcm-docker
+        echo "::endgroup::"
+        echo "::group::Dockerfile used to build mc_naoqi_dcm"
+        cat Dockerfile
+        echo "::endgroup::"
+        echo "::group::Build base image"
+        docker build -t mc_naoqi_dcm-ci-${{matrix.os}} .
+        echo "::endgroup::"
+        echo "::group::Copy built library"
+        id=$(docker create mc_naoqi_dcm-ci-${{matrix.os}})
+        docker cp $id:/libmc_naoqi_dcm.so /tmp/libmc_naoqi_dcm.so 
+        docker rm -v $id
+        echo "::endgroup::"
+    - name: Upload build
+      uses: actions/upload-artifact@master
+      with:
+        name: libmc_naoqi_dcm.so 
+        path: /tmp/libmc_naoqi_dcm.so
+    # - name: Slack Notification
+    #   if: failure()
+    #   uses: archive/github-actions-slack@master
+    #   with:
+    #     slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_TOKEN }}
+    #     slack-channel: '#ci'
+    #     slack-text: >
+    #       [mc_naoqi_dcm] Build *${{ matrix.os }}* failed on ${{ github.ref }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: Build within Docker
+    - name: Build within Docker (Pepper)
       run: |
         echo "::group::Setup Dockerfile"
         mkdir -p /tmp/mc_naoqi_dcm-docker
@@ -39,23 +39,39 @@ jobs:
         cat Dockerfile
         echo "::endgroup::"
         echo "::group::Build base image"
-        docker build -t mc_naoqi_dcm-ci-${{matrix.os}} .
+        docker build -t mc_naoqi_dcm-ci-${{matrix.os}}-pepper .
         echo "::endgroup::"
         echo "::group::Copy built library"
-        id=$(docker create mc_naoqi_dcm-ci-${{matrix.os}})
-        docker cp $id:/libmc_naoqi_dcm.so /tmp/libmc_naoqi_dcm.so 
+        id=$(docker create mc_naoqi_dcm-ci-${{matrix.os}}-pepper)
+        docker cp $id:/libmc_naoqi_dcm.so /tmp/libmc_naoqi_dcm_pepper.so 
         docker rm -v $id
         echo "::endgroup::"
-    - name: Upload build
+    - name: Upload library as artefact (pepper)
       uses: actions/upload-artifact@master
       with:
-        name: libmc_naoqi_dcm.so 
-        path: /tmp/libmc_naoqi_dcm.so
-    # - name: Slack Notification
-    #   if: failure()
-    #   uses: archive/github-actions-slack@master
-    #   with:
-    #     slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_TOKEN }}
-    #     slack-channel: '#ci'
-    #     slack-text: >
-    #       [mc_naoqi_dcm] Build *${{ matrix.os }}* failed on ${{ github.ref }}
+        name: libmc_naoqi_dcm_pepper.so 
+        path: /tmp/libmc_naoqi_dcm_pepper.so
+    - name: Build within Docker (NAO)
+      run: |
+        echo "::group::Setup Dockerfile"
+        mkdir -p /tmp/mc_naoqi_dcm-docker-nao
+        cp -r `pwd` /tmp/mc_naoqi_dcm-docker-nao/mc_naoqi_dcm
+        sed 's/ROBOT_NAME=pepper/ROBOT_NAME=nao/g' .github/workflows/docker/Dockerfile.${{ matrix.os }} | tee /tmp/mc_naoqi_dcm-docker-nao/Dockerfile
+        cd /tmp/mc_naoqi_dcm-docker-nao
+        echo "::endgroup::"
+        echo "::group::Dockerfile used to build mc_naoqi_dcm"
+        cat Dockerfile
+        echo "::endgroup::"
+        echo "::group::Build base image"
+        docker build -t mc_naoqi_dcm-ci-${{matrix.os}}-nao .
+        echo "::endgroup::"
+        echo "::group::Copy built library"
+        id=$(docker create mc_naoqi_dcm-ci-${{matrix.os}}-nao)
+        docker cp $id:/libmc_naoqi_dcm.so /tmp/libmc_naoqi_dcm_nao.so 
+        docker rm -v $id
+        echo "::endgroup::"
+    - name: Upload library as artefact (NAO)
+      uses: actions/upload-artifact@master
+      with:
+        name: libmc_naoqi_dcm_nao.so 
+        path: /tmp/libmc_naoqi_dcm_nao.so

--- a/.github/workflows/docker/Dockerfile.ubuntu_20.04
+++ b/.github/workflows/docker/Dockerfile.ubuntu_20.04
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq && apt-get install -qq cmake cmake-data wget lsb-release git sudo python3 python3-pip
+RUN python3 -m pip install qibuild
+RUN mkdir /Workspace && cd /Workspace \
+  && wget -c https://seafile.lirmm.fr/f/5389d0a64d79481ab49e/?dl=1 -O ctc-naoqi.tar.xz \
+  && tar -xf ctc-naoqi.tar.xz \
+  && mv ctc-naoqi-2.5.0 ctc-naoqi \
+  && qitoolchain create ctc-naoqi ctc-naoqi/toolchain.xml \
+  && mkdir qibuild_ws && cd qibuild_ws \
+  && qibuild init \
+  && qibuild add-config ctc-naoqi-config -t ctc-naoqi --default
+
+COPY mc_naoqi_dcm /Workspace/qibuild_ws/mc_naoqi_dcm
+RUN cd /Workspace/qibuild_ws/mc_naoqi_dcm \
+ && qibuild configure --release -DROBOT_NAME=pepper \
+ && qibuild make \
+ && mv /Workspace/qibuild_ws/mc_naoqi_dcm/build-ctc-naoqi-config/sdk/lib/naoqi/libmc_naoqi_dcm.so /libmc_naoqi_dcm.so
+RUN ls /
+RUN echo "Created library: /mc_naoqi_dcm.so"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq && apt-get install -qq cmake cmake-data wget lsb-release git sudo python3 python3-pip
+RUN python3 -m pip install qibuild
+RUN mkdir /Workspace && cd /Workspace \
+  && wget -c https://seafile.lirmm.fr/f/5389d0a64d79481ab49e/?dl=1 -O ctc-naoqi.tar.xz \
+  && tar -xf ctc-naoqi.tar.xz \
+  && mv ctc-naoqi-2.5.0 ctc-naoqi \
+  && qitoolchain create ctc-naoqi ctc-naoqi/toolchain.xml \
+  && mkdir qibuild_ws && cd qibuild_ws \
+  && qibuild init \
+  && qibuild add-config ctc-naoqi-config -t ctc-naoqi --default
+
+COPY . /Workspace/qibuild_ws/mc_naoqi_dcm
+RUN cd /Workspace/qibuild_ws/mc_naoqi_dcm \
+ && qibuild configure --release -DROBOT_NAME=pepper \
+ && qibuild make \
+ && mv /Workspace/qibuild_ws/mc_naoqi_dcm/build-ctc-naoqi-config/sdk/lib/naoqi/libmc_naoqi_dcm.so /libmc_naoqi_dcm.so
+RUN ls /
+RUN echo "Created library: /mc_naoqi_dcm.so"

--- a/README.md
+++ b/README.md
@@ -1,26 +1,36 @@
 # mc_naoqi_dcm
+[![CI of mc_naoqi_dcm with Docker](https://github.com/jrl-umi3218/mc_naoqi_dcm/actions/workflows/build-docker.yml/badge.svg)](https://github.com/jrl-umi3218/mc_naoqi_dcm/actions/workflows/build-docker.yml)
 
 Fast communication module between NAO/PEPPER robot sensors and actuators and [`mc_rtc`](https://jrl-umi3218.github.io/mc_rtc/index.html) control framework.
 This is a local robot module, which needs to be cross-compiled for the desired platform (NAO or Pepper), and uploaded on the robot. This module provides fast access to the low level [Device Communication Manager](https://developer.softbankrobotics.com/pepper-naoqi-25/naoqi-developer-guide/naoqi-apis/dcm) module of [NAOqi OS](https://developer.softbankrobotics.com/pepper-naoqi-25), it allows to set/get actuator values under 12ms.
 
-## Building
+# Building
 
-This module needs to be cross-compiled and sent to the robot.
+This module needs to be cross-compiled and sent to the robot. For this you have three options (choose which one fits you best):
+
+## Option 1: Build locally using the cross compilation toolchain
 
 ### 1. Installing `qiBuild` and creating a worktree
 
 1. Install **qiBuild**: `pip install qibuild --user`
 1. Configure **qiBuild**: `qibuild config --wizard`
-1. Create a **qiBuild worktree**: `mkdir qiBuild_wt`
-1. Enter **qiBuild worktree**: `cd qiBuild_wt`
+1. Create a **qiBuild worktree**: `mkdir qibuild_ws`
+1. Enter **qiBuild worktree**: `cd qibuild_ws`
 1. Initialize your worktree: `qibuild init`
 
 ### 2. Downloading and configuring cross-compilation toolchain
 
-1. Download [Cross Toolchain](https://developer.softbankrobotics.com/pepper-naoqi-25-downloads-linux): `ctc-linux64-atom-x.x.x.x.zip`
-1. Extract this archive into (e.g.) `ctc-naoqi` folder
-1. Create toolchain for cross compilation: `qitoolchain create ctc-naoqi ctc-naoqi/toolchain.xml`
-1. Enter previously created **qiBuild worktree**: `cd qiBuild_wt`
+1. Download the [Cross Compilation Toolchain](https://developer.softbankrobotics.com/pepper-naoqi-25-downloads-linux). Unfortunately the toolchain required for naoqi 2.5 is no longer officially provided, you may download a copy here:
+   ```sh
+   wget -c https://seafile.lirmm.fr/f/5389d0a64d79481ab49e/?dl=1 -O ctc-naoqi.tar.xz
+   ```
+   We advise you to keep a copy of that archive in case the above link becomes unavailable as this archive cannot be found elsewhere online.
+1. Extract this archive
+   ```sh
+   tar -xf ctc-naoqi.tar.xz .
+   ```
+1. Create toolchain for cross compilation: `qitoolchain create ctc-naoqi ctc-naoqi-2.5.0/toolchain.xml`
+1. Enter previously created **qiBuild worktree**: `cd qibuild_ws`
 1. Create toolchain build configuration and set it as default in your **qiBuild worktree**: `qibuild add-config ctc-naoqi-config -t ctc-naoqi --default`
 
 ### 3. Clone and build `mc_naoqi_dcm`
@@ -34,11 +44,34 @@ This module needs to be cross-compiled and sent to the robot.
   as: loadlocale.c:129: _nl_intern_locale_data: Assertion `cnt < (sizeof (_nl_value_type_LC_TIME) / sizeof (_nl_value_type_LC_TIME[0]))' failed.
   ```
 
-### 4. Upload module to the robot and configure autoload
+You may now upload `qibuild_ws/mc_naoqi_dcm/build-ctc-naoqi-config/sdk/lib/naoqi/libmc_naoqi_dcm.so` to the robot.
+
+## Option 2: Build using the provided Dockerfile
+
+You may use the provided `Dockerfile` that sets up the cross-compilation environment for you. If you already followed `Option 1` this is not necessary.
+
+```sh
+cd <mc_naoqi_dcm>
+docker build -t docker-naoqi-dcm .
+id=$(docker create docker-naoqi-dcm)
+docker cp $id:/libmc_naoqi_dcm.so /tmp/libmc_naoqi_dcm.so
+docker rm -v $id
+```
+You may now upload the `/tmp/libmc_naoqi_dcm.so` on the robot
+
+## Option 3: Using the pre-built library
+
+You may find a pre-built version of `libmc_naoqi_dcm.so` in the [Github Artefacts](https://github.com/arntanguy/mc_naoqi_dcm/actions/workflows/build-docker.yml): click on `[CI of mc_naoqi_dcm with Docker]` then click on the latest successful action and scroll down to the Artefacts section where you can download the pre-compiled `libmc_naoqi_dcm.so` library.
+
+# Installing on the robot
+
+The installation consists of uploading the module to the robot and making it automatically load on startup
 
 1. Transfer `libmc_naoqi_dcm.so` file to the robot:
 ```bash
-rsync build-ctc-naoqi-config/sdk/lib/naoqi/libmc_naoqi_dcm.so nao@pepper.local:/home/nao/naoqi/
+rsync build-ctc-naoqi-config/sdk/lib/naoqi/libmc_naoqi_dcm.so nao@pepper.local:/home/nao/naoqi/ # For Option 1
+# Or: 
+rsync /tmp/libmc_naoqi_dcm.so nao@pepper.local:/home/nao/naoqi/ # For Option 2
 ```
 2. Login to robot system:
 ```bash
@@ -58,10 +91,7 @@ to contain the following line:
 nao restart
 ```
 
-### 5. All done | Next steps
+# All done | Next steps
 The robot is now running our uploaded local module `mc_naoqi_dcm` and is ready to be controlled via [`mc_rtc`](https://jrl-umi3218.github.io/mc_rtc/index.html) controller using [`mc_naoqi`](https://github.com/jrl-umi3218/mc_naoqi) interface.
 
 You can refer to the sample Pepper Finite State Machine (FSM) `mc_rtc` controller  project: [`PepperFSMController`](https://github.com/jrl-umi3218/pepper-fsm-controller) for an example (or a starting point) for creating your own `mc_rtc` controller for Pepper.
-
----
-The URLs in this file were valid on 20.07.20


### PR DESCRIPTION
This PR:
- Adds a CI to build `libmc_naoqi_dcm_pepper.so` and `libmc_naoqi_dcm_nao.so` with a `Dockerfile`. The CI uploads the pre-built libraries as github artifacts, and one can directly upload this pre-built library on our pepper robots
- Add instructions on how to build locally using the Docker file
- Provide a link to the cross compilation toolchain for `naoqi 2.5`. This `ctc-toolchain` can no longer be found on the official website.
